### PR TITLE
Update .deb control file

### DIFF
--- a/build.py
+++ b/build.py
@@ -282,6 +282,8 @@ def generate_control_file(version):
 
     content = """Package: rustdesk
 Version: %s
+Section: net
+Priority: optional
 Architecture: %s
 Maintainer: rustdesk <info@rustdesk.com>
 Homepage: https://rustdesk.com


### PR DESCRIPTION
Add `Section` and `Priority` fields to control file for .deb packages.

While the package will install with these fields missing tools such as `rerepro` will fail, breaking local repositories.